### PR TITLE
docs: translate README to Korean

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# swift-study
+# 스위프트 공부
+
+스위프트 언어를 학습하면서 작성한 플레이그라운드 모음입니다. 각 폴더는 특정 개념을 다룹니다.
+
+## 시작하기
+
+1. [Xcode](https://developer.apple.com/xcode/) 또는 [Swift Playgrounds](https://www.apple.com/swift/playgrounds/)를 설치합니다.
+2. 이 저장소를 클론합니다.
+3. 원하는 `.playground` 파일을 열어 예제를 실행해 봅니다.
+
+## 주제
+
+| 플레이그라운드 | 설명 |
+|----------------|------|
+| 1Basic.playground | 기본 문법, 변수, 주석 |
+| 1Basic2.playground | 추가 기본 예제 |
+| 2Enum.playground | 열거형 |
+| 3Operator.playground | 연산자 |
+| 4ControlFlow.playground | 제어 흐름 |
+| 5Function.playground | 함수 |
+| 6Optional.playground | 옵셔널 |
+| 7Struct&Class.playground | 구조체와 클래스 |
+| 8Property.playground | 프로퍼티 |
+| 9Initialization.playground | 초기화 |
+| 10Access.playground | 접근 제어 |
+| 11Inheritance.playground | 상속 |
+| 12TypeCasting.playground | 타입 캐스팅 |
+| 13Protocol.playground | 프로토콜 |
+| 14Extension.playground | 익스텐션 |
+| 15Generic.playground | 제네릭 |
+| 16Closer.playground | 클로저 |
+| 17Map&Filter&Reduce.playground | 고차 함수: `map`, `filter`, `reduce` |
+| 18Concurrency.playground | 동시성 |
+| 18OptionalChaining.playground | 옵셔널 체이닝 |
+| 19ErrorHandling.playground | 에러 처리 |
+
+## 연습
+
+`Practice*.playground` 폴더에는 위 주제들을 복습할 수 있는 연습 문제가 있습니다. 일부 폴더는 `Practice06-answer.playground`처럼 정답 파일을 포함합니다.
+
+## 기여
+
+Swift를 계속 공부하면서 새로운 플레이그라운드를 추가하거나 기존 예제를 개선해 주세요.


### PR DESCRIPTION
## Summary
- translate README to Korean with setup steps and topic table for Swift playgrounds

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b94e32e4f48324b5a0cf6d7b78e1e8